### PR TITLE
Allow a promise for asynchronously loading configs

### DIFF
--- a/src/__tests__/__snapshots__/on-create-node.test.ts.snap
+++ b/src/__tests__/__snapshots__/on-create-node.test.ts.snap
@@ -1,5 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`onCreateNode allows Promise based options 1`] = `
+Object {
+  "body": "{\\"query\\":\\"query { id }\\",\\"variables\\":{}}",
+  "headers": Object {
+    "authorization": "Bearer token",
+    "content-type": "application/json",
+  },
+  "method": "post",
+}
+`;
+
 exports[`onCreateNode allows passing custom headers 1`] = `
 Object {
   "body": "{\\"query\\":\\"query { id }\\",\\"variables\\":{}}",

--- a/src/__tests__/on-create-node.test.ts
+++ b/src/__tests__/on-create-node.test.ts
@@ -71,6 +71,20 @@ describe('onCreateNode', () => {
     })
   })
 
+  it('allows Promise based options', async () => {
+    mockFetch()
+
+    const headers = {
+      authorization: 'Bearer token',
+    }
+    const loadNodeContent = jest.fn(() => 'query { id }')
+    const gatsby = createGatsby({ loadNodeContent })
+    const options = Promise.resolve(createOptions({ headers }))
+    const actual = await onCreateNode(gatsby, options)
+
+    expect(fetch.mock.calls[0][1]).toMatchSnapshot()
+  })
+
   it('allows passing custom headers', async () => {
     mockFetch()
 

--- a/src/on-create-node.ts
+++ b/src/on-create-node.ts
@@ -8,7 +8,7 @@ const startCase = upperCaseBy(/^(\w)/)
 
 const onCreateNode = async (
   { boundActionCreators: { createNode, createParentChildLink }, loadNodeContent, node },
-  { headers = {}, url, variables = {} }: Options
+  config: Options | Promise<Options>
 ) => {
   if ( node.extension !== 'graphql' ) {
     return
@@ -16,6 +16,10 @@ const onCreateNode = async (
 
   const query = await loadNodeContent(node)
   const queries = [ query ]
+
+  // Resolve configurations.
+  config = 'then' in config ? await config : config;
+  const { headers = {}, url, variables = {} } = config;
 
   validate({ headers, queries, url, variables })
 

--- a/src/on-create-node.ts
+++ b/src/on-create-node.ts
@@ -18,8 +18,7 @@ const onCreateNode = async (
   const queries = [ query ]
 
   // Resolve configurations.
-  config = 'then' in config ? await config : config;
-  const { headers = {}, url, variables = {} } = config;
+  const { headers = {}, url, variables = {} } = await config;
 
   validate({ headers, queries, url, variables })
 


### PR DESCRIPTION
Would you be okay with allowing the options to be defined as a promise that will resolve to the options?

## Problem:
I need to dynamically request a JWT token for authorization of the GraphQL request, so I can't just define it in the plugin config as such:
```
    {
      resolve: 'gatsby-source-graphql',
      options: {
        headers: {
          authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
        },
        url: 'https://api.github.com/graphql',
      },
    },
```
## Solution:
Instead, it would be great to be able to request the token and asynchronously resolve to the configs.  Something like so:
```
    {
      resolve: 'gatsby-source-graphql',
      options: getAuthToken().then(token => ({
        headers: {
          authorization: `Bearer ${token}`,
        },
        url: 'https://example.com/graphql',
      })),
    },
```