### PR TITLE
Allow the use of a mapper function between results and nodes

### DIFF
--- a/src/__tests__/__snapshots__/on-create-node.test.ts.snap
+++ b/src/__tests__/__snapshots__/on-create-node.test.ts.snap
@@ -1,5 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`onCreateNode allows Promise based options 1`] = `
+Object {
+  "body": "{\\"query\\":\\"query { id }\\",\\"variables\\":{}}",
+  "headers": Object {
+    "authorization": "Bearer token",
+    "content-type": "application/json",
+  },
+  "method": "post",
+}
+`;
+
 exports[`onCreateNode allows passing custom headers 1`] = `
 Object {
   "body": "{\\"query\\":\\"query { id }\\",\\"variables\\":{}}",

--- a/src/__tests__/on-create-node.test.ts
+++ b/src/__tests__/on-create-node.test.ts
@@ -71,6 +71,28 @@ describe('onCreateNode', () => {
     })
   })
 
+  it('allow the use to a mapper function', async () => {
+    mockFetch()
+
+    const createNode = jest.fn()
+    const loadNodeContent = jest.fn(() => 'query { id }')
+    const gatsby = createGatsby({ createNode, loadNodeContent })
+    const options = { ...createOptions(), map: data => ({ ...data, type: 'CustomType' }) }
+    const actual = await onCreateNode(gatsby, options)
+    const contentDigest = 'b035be5e1e4d06e6faaf0fc2d9f2f77f'
+
+    expect(createNode.mock.calls[0][0]).toEqual({
+      type: 'CustomType',
+      id: `__graphql__${contentDigest}`,
+      children: [],
+      internal: {
+        content: JSON.stringify({ id: 1, type: 'CustomType' }),
+        contentDigest,
+        type: 'CustomType',
+      },
+    })
+  })
+
   it('allows Promise based options', async () => {
     mockFetch()
 

--- a/src/__tests__/on-create-node.test.ts
+++ b/src/__tests__/on-create-node.test.ts
@@ -71,6 +71,20 @@ describe('onCreateNode', () => {
     })
   })
 
+  it('allows Promise based options', async () => {
+    mockFetch()
+
+    const headers = {
+      authorization: 'Bearer token',
+    }
+    const loadNodeContent = jest.fn(() => 'query { id }')
+    const gatsby = createGatsby({ loadNodeContent })
+    const options = Promise.resolve(createOptions({ headers }))
+    const actual = await onCreateNode(gatsby, options)
+
+    expect(fetch.mock.calls[0][1]).toMatchSnapshot()
+  })
+
   it('allows passing custom headers', async () => {
     mockFetch()
 

--- a/src/on-create-node.ts
+++ b/src/on-create-node.ts
@@ -8,7 +8,7 @@ const startCase = upperCaseBy(/^(\w)/)
 
 const onCreateNode = async (
   { boundActionCreators: { createNode, createParentChildLink }, loadNodeContent, node },
-  { headers = {}, url, variables = {} }: Options
+  config: Options | Promise<Options>
 ) => {
   if ( node.extension !== 'graphql' ) {
     return
@@ -16,6 +16,10 @@ const onCreateNode = async (
 
   const query = await loadNodeContent(node)
   const queries = [ query ]
+
+  // Resolve configurations.
+  config = 'then' in config ? await config : config;
+  const { headers = {}, url, variables = {} } = config;
 
   validate({ headers, queries, url, variables })
 

--- a/src/on-create-node.ts
+++ b/src/on-create-node.ts
@@ -18,8 +18,7 @@ const onCreateNode = async (
   const queries = [ query ]
 
   // Resolve configurations.
-  config = 'then' in config ? await config : config;
-  const { headers = {}, url, variables = {} } = config;
+  const { headers = {}, url, variables = {} } = await config;
 
   validate({ headers, queries, url, variables })
 

--- a/src/on-create-node.ts
+++ b/src/on-create-node.ts
@@ -18,7 +18,7 @@ const onCreateNode = async (
   const queries = [ query ]
 
   // Resolve configurations.
-  const { headers = {}, url, variables = {} } = await config;
+  const { headers = {}, url, variables = {}, map } = await config
 
   validate({ headers, queries, url, variables })
 
@@ -37,23 +37,32 @@ const onCreateNode = async (
     throw new Error(`[${response.statusText}]: ${result.message}`)
   }
 
-  const content = JSON.stringify(result.data)
-  const contentDigest = createContentDigest(content)
-  const type = startCase(camelCase(`${node.name}GraphQL`))
-  const child = {
-    ...result.data,
-    id: `__graphql__${contentDigest}`,
-    children: [],
-    parent: node.id,
-    internal: {
-      content,
-      contentDigest,
-      type,
-    },
+  let nodes = [ result.data ]
+  if (map) {
+    nodes = map(result.data)
+    if (!Array.isArray(nodes)) {
+      nodes = [ nodes ]
+    }
   }
 
-  createNode(child)
-  createParentChildLink({ parent: node, child })
+  nodes.forEach(newNode => {
+    const content = JSON.stringify(newNode)
+    const contentDigest = createContentDigest(content)
+    const child = {
+      ...newNode,
+      id: `__graphql__${contentDigest}`,
+      children: [],
+      parent: node.id,
+      internal: {
+        content,
+        contentDigest,
+        type: newNode.type ? newNode.type : startCase(camelCase(`${node.name}GraphQL`)),
+      },
+    }
+
+    createNode(child)
+    createParentChildLink({ parent: node, child })
+  });
 
   return
 }

--- a/src/utils/validate.ts
+++ b/src/utils/validate.ts
@@ -7,6 +7,7 @@ type Options = {
   variables: {
     [ variable: string ]: any,
   },
+  map?: (data: any) => any | any[],
 }
 
 const isObject = <T>( value: T ) =>
@@ -14,7 +15,7 @@ const isObject = <T>( value: T ) =>
     && Array.isArray(value) === false
     && value !== null
 
-const validate = ({ headers, queries, url, variables }: Options) => {
+const validate = ({ headers, queries, url, variables, map }: Options) => {
   if ( !(Array.isArray(queries) && queries.length > 0) ) {
     throw new Error('Must supply `queries` option with atleast one query.')
   }
@@ -29,6 +30,10 @@ const validate = ({ headers, queries, url, variables }: Options) => {
 
   if ( !isObject(variables) ) {
     throw new Error('Must supply `variables` option that is an object.')
+  }
+
+  if ( !(typeof map === 'undefined' || typeof map === 'function') ) {
+    throw new Error('Can supply `map` option that is a function.')
   }
 }
 


### PR DESCRIPTION
Would it be possible to allow a user to define more than one nodes per graphql query?

## Problem:
I don't want to define a graphql query for every object on my server.  I have an articles.graphql file that requests a list of all my articles, and I would like to get each article as its own node.

## Solution:
Allow the user to define a `map` configuration option that allows it to receive the data and return a list of objects to be used as nodes.